### PR TITLE
Add top-level Makefile and make watch command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+SHELL := /usr/bin/env bash
+
+watch:
+	watchmedo shell-command \
+		--patterns="*.rst" \
+		--ignore-pattern='_build/*' \
+		--recursive \
+		--command='make docs'
+
+docs:
+	$(MAKE) -C docs html
+
+clean:
+	$(MAKE) -C docs clean
+
+.PHONY: docs watch clean

--- a/README.txt
+++ b/README.txt
@@ -7,9 +7,13 @@ Building the Documentation
 
 To prepare to build this documentation:
 
+    mkvirtualenv marketplace-docs
     pip install -r requirements/docs.txt
 
 To build this documentation:
 
-    cd docs
-    make html
+    make docs
+
+To have changes built as they happen:
+
+    make watch

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -4,3 +4,4 @@ docutils==0.9.1
 Pygments==1.5
 Sphinx==1.1.3
 mdn-sphinx-theme>=0.3
+watchdog==0.8.0


### PR DESCRIPTION
This adds a top-level Makefile and a `make watch` command which will watch for changes and rebuild the docs on the fly.

To try it you'll need the up to date deps to pull in the watchdog dep.
