### PR TITLE
Fix some documentation errors

### DIFF
--- a/docs/topics/docker.rst
+++ b/docs/topics/docker.rst
@@ -29,8 +29,8 @@ Get the code::
     git clone https://github.com/mozilla/wharfie
     cd wharfie
 
-    bin/wharfie whoami [your github user name]
-    bin/wharfie checkout
+    bin/mkt whoami [your github user name]
+    bin/mkt checkout
 
     pip install virtualenvwrapper
     mkvirtualenv wharfie
@@ -59,8 +59,14 @@ For linux just add a hosts entry for localhost::
 
 Run::
 
-    fig build
-    fig run
+    $ fig build
+
+    $ fig run mysql /bin/bash
+        # mysqld_safe &
+        # mysql -uroot
+          create database zamboni;
+    $ fig run zamboni python manage.py syncdb
+    $ fig up
 
 .. note:: This can take a long time.
 

--- a/docs/topics/setup.rst
+++ b/docs/topics/setup.rst
@@ -27,7 +27,7 @@ Services
   Written in Python and Django - `webpay source <https://github.com/mozilla/solitude/>`_,
   `webpay docs <https://webpay.readthedocs.org>`_, `solitude source
   <https://github.com/mozilla/webpay/>`_, `solitude docs
-  <https://solitdue.readthedocs.org>`_
+  <https://solitude.readthedocs.org>`_
 
 * **Spartacus**: the front end for webpay. Written in Javascript - `source <https://github.com/mozilla/spartacus>`_
 


### PR DESCRIPTION
There are a few things I noticed that are wrong in the setup documentation. I'm not sure how the mysql database is supposed to be initialized, but doing the fig run commands below seemed to at least get the site up and running. There are still some issues(persona login fails because of non-https/data-uri logo), and the syncdb command fails to set up admins(not sure if that is as designed), see traceback below:

```
Traceback (most recent call last):
  File "manage.py", line 81, in <module>
    execute_from_command_line(sys.argv)
  File "/opt/rh/python27/root/usr/lib/python2.7/site-packages/django/core/management/__init__.py", line 399, in execute_from_command_line
    utility.execute()
  File "/opt/rh/python27/root/usr/lib/python2.7/site-packages/django/core/management/__init__.py", line 392, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/opt/rh/python27/root/usr/lib/python2.7/site-packages/django/core/management/base.py", line 242, in run_from_argv
    self.execute(*args, **options.__dict__)
  File "/opt/rh/python27/root/usr/lib/python2.7/site-packages/django/core/management/base.py", line 285, in execute
    output = self.handle(*args, **options)
  File "/opt/rh/python27/root/usr/lib/python2.7/site-packages/django/core/management/base.py", line 415, in handle
    return self.handle_noargs(**options)
  File "/opt/rh/python27/root/usr/lib/python2.7/site-packages/django/core/management/commands/syncdb.py", line 112, in handle_noargs
    emit_post_sync_signal(created_models, verbosity, interactive, db)
  File "/opt/rh/python27/root/usr/lib/python2.7/site-packages/django/core/management/sql.py", line 216, in emit_post_sync_signal
    interactive=interactive, db=db)
  File "/opt/rh/python27/root/usr/lib/python2.7/site-packages/django/dispatch/dispatcher.py", line 185, in send
    response = receiver(signal=self, sender=sender, **named)
  File "/opt/rh/python27/root/usr/lib/python2.7/site-packages/django/contrib/auth/management/__init__.py", line 126, in create_superuser
    call_command("createsuperuser", interactive=True, database=db)
  File "/opt/rh/python27/root/usr/lib/python2.7/site-packages/django/core/management/__init__.py", line 159, in call_command
    return klass.execute(*args, **defaults)
  File "/opt/rh/python27/root/usr/lib/python2.7/site-packages/raven/contrib/django/management/__init__.py", line 37, in new_execute
    return original_func(self, *args, **kwargs)
  File "/opt/rh/python27/root/usr/lib/python2.7/site-packages/django/core/management/base.py", line 285, in execute
    output = self.handle(*args, **options)
  File "/opt/rh/python27/root/usr/lib/python2.7/site-packages/django/contrib/auth/management/commands/createsuperuser.py", line 102, in handle
    self.UserModel._default_manager.db_manager(database).get_by_natural_key(username)
AttributeError: 'ManagerBase' object has no attribute 'get_by_natural_key'
```
