### PR TITLE
shifts code order on 'build dependencies'

### DIFF
--- a/docs/topics/backend.rst
+++ b/docs/topics/backend.rst
@@ -52,15 +52,15 @@ Get the code::
 
     git clone https://github.com/mozilla/marketplace-env
     cd marketplace-env
-
-    bin/mkt whoami [your github user name]
-    bin/mkt checkout
-
+    
     pip install virtualenvwrapper
     mkvirtualenv marketplace-env
     workon marketplace-env
     pip install --upgrade pip
     pip install -r requirements.txt
+
+    bin/mkt whoami [your github user name]
+    bin/mkt checkout
 
 On OSX
 ~~~~~~


### PR DESCRIPTION
It's a minor issue but shouldn't virtualenv and requirements.txt installation come before running "bin/mkt whoami [your github user name]"? 
Reason: error for not having "netifaces" installed from "requirements.txt" yet if you don't already have it installed globally

```
$ bin/mkt whoami marcoagner
Traceback (most recent call last):
  File "bin/mkt", line 3, in <module>
    import cmds
  File "/Users/marcoagner/Projects/marketplace-env/mkt/cmds.py", line 13, in <module>
    import netifaces
ImportError: No module named netifaces
```
