### PR TITLE
Include `boot2docker init` in Mac installation instructions.

### DIFF
--- a/docs/topics/backend.rst
+++ b/docs/topics/backend.rst
@@ -44,6 +44,7 @@ easily using `homebrew <http://brew.sh/>`_ with the following::
     brew install caskroom/cask/brew-cask
     brew cask install virtualbox
     brew install docker boot2docker
+    boot2docker init
 
 If you're using Boot2docker once you've created the vm it will tell you how to export
 variables in your shell in order to be able to communicate with the boot2docker vm.


### PR DESCRIPTION
When attempting to `boot2docker up` per the instructions, I got:

    error in run: Failed to get machine "boot2docker-vm": machine not exist

At @washort's suggestion I ran `boot2docker init` and everything seemed to go smoothly from there.

r? @muffinresearch 