### PR TITLE
Update backend.rst

### DIFF
--- a/docs/topics/backend.rst
+++ b/docs/topics/backend.rst
@@ -90,8 +90,7 @@ directory (e.g.: ~/sandbox/):
   * `zamboni <https://github.com/mozilla/zamboni/>`_
   * `zippy <https://github.com/mozilla/zippy/>`_
   
-  
-On Linux::
+In the directory where you'd like the sandbox to reside::
     mkdir sandbox; cd sandbox
     echo https://github.com/mozilla/fireplace.git https://github.com/mozilla/solitude.git https://github.com/mozilla/spartacus.git https://github.com/mozilla/webpay.git https://github.com/mozilla/zamboni.git https://github.com/mozilla/zippy.git| xargs -n 1 git clone 
 

--- a/docs/topics/backend.rst
+++ b/docs/topics/backend.rst
@@ -89,6 +89,11 @@ directory (e.g.: ~/sandbox/):
   * `webpay <https://github.com/mozilla/webpay/>`_
   * `zamboni <https://github.com/mozilla/zamboni/>`_
   * `zippy <https://github.com/mozilla/zippy/>`_
+  
+  
+On Linux::
+    mkdir sandbox; cd sandbox
+    echo https://github.com/mozilla/fireplace.git https://github.com/mozilla/solitude.git https://github.com/mozilla/spartacus.git https://github.com/mozilla/webpay.git https://github.com/mozilla/zamboni.git https://github.com/mozilla/zippy.git| xargs -n 1 git clone 
 
 Get the marketplace environment repo and set up the configuration files needed
 for docker-compose. This can live under the same directory as the above repos::


### PR DESCRIPTION
Update documentation to make cloning repos faster, currently requires visiting each web page and manually getting each repo. Submitted line of script uses xargs to process this list. 