### PR TITLE
Update backend.rst - change script to get parent dir

### DIFF
--- a/docs/topics/backend.rst
+++ b/docs/topics/backend.rst
@@ -91,11 +91,11 @@ directory (e.g.: ~/sandbox/):
   * `zippy <https://github.com/mozilla/zippy/>`_
 
 Get the marketplace environment repo and set up the configuration files needed
-for docker-compose. This can live under the same directory as the above repos::
+for docker-compose. Still in the sandbox directory::
 
     git clone https://github.com/mozilla/marketplace-env.git
     cd marketplace-env
-    python link-sources.py --root <repo_root_path>
+    python link-sources.py --root $(dirname $(pwd))
 
 Set up the environment variable that `docker-compose` looks for::
 


### PR DESCRIPTION
Use the shell to get the parent directory of pwd using $(command) instead of asking the user to manually provide it