### PR TITLE
Add instructions to install docker-compose

### DIFF
--- a/docs/topics/backend.rst
+++ b/docs/topics/backend.rst
@@ -33,6 +33,7 @@ Requirements
 -----------------
 
 `Install Docker <https://docs.docker.com/installation/>`_.
+`Install docker-compose <https://docs.docker.com/compose/install/>`_.
 
 On OSX
 ~~~~~~


### PR DESCRIPTION
Otherwise install on clean system fails and the user might not be familiar enough with docker to know that docker-compose is installed separately.